### PR TITLE
Provide blockchain data to user for signatures and providers

### DIFF
--- a/dist/opensig-js.js
+++ b/dist/opensig-js.js
@@ -24,6 +24,7 @@ var opensig = (function (exports) {
   class BlockchainProvider {
 
     constructor(params) {
+      this.params = params;
       this.name = params.name;
       this.chainId = params.chainId;
       this.contract = params.contract;

--- a/dist/opensig-js.js
+++ b/dist/opensig-js.js
@@ -279,9 +279,6 @@ var opensig = (function (exports) {
   }
 
   // Copyright (c) 2023 Bubble Protocol
-  // Distributed under the MIT software license, see the accompanying
-  // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-
 
 
   //
@@ -396,9 +393,6 @@ var opensig = (function (exports) {
   }
 
   // Copyright (c) 2023 Bubble Protocol
-  // Distributed under the MIT software license, see the accompanying
-  // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-
 
   /**
    * opensig.js
@@ -628,6 +622,7 @@ var opensig = (function (exports) {
       event.topics.slice(1)
     );
     return {
+      event,
       time: decodedEvent.time,
       signatory: decodedEvent.signer,
       signature: decodedEvent.signature,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensig-js",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenSig javascript library for publishing digital signatures to EVM-based blockchains.",
   "main": "src/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensig-js",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenSig javascript library for publishing digital signatures to EVM-based blockchains.",
   "main": "src/index.js",
   "type": "module",

--- a/src/opensig.js
+++ b/src/opensig.js
@@ -234,6 +234,7 @@ async function _decodeSignatureEvent(event, encryptionKey) {
     event.topics.slice(1)
   )
   return {
+    event,
     time: decodedEvent.time,
     signatory: decodedEvent.signer,
     signature: decodedEvent.signature,

--- a/src/providers.js
+++ b/src/providers.js
@@ -21,6 +21,7 @@ const defaultABI = [ { anonymous: false, inputs: [ { indexed: false, internalTyp
 export class BlockchainProvider {
 
   constructor(params) {
+    this.params = params;
     this.name = params.name;
     this.chainId = params.chainId;
     this.contract = params.contract;


### PR DESCRIPTION
Implements #1.

Introduces a new `event` field within a signature object containing the signature's blockchain event data in the format defined here: https://web3js.readthedocs.io/en/v1.10.0/web3-eth.html?highlight=structure#getpastlogs

Also introduces a new `params` field within the `BlockchainProvider` class that references the object used to construct it. Allows users to add custom fields to a provider.